### PR TITLE
Mlr 183 - Cross reference validations now work for update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - pip install coveralls
 
 script:
-  - coverage run --omit=tests/*.py,/home/travis/virtualenv/* -m unittest
+  - coverage run --omit=*/tests/*.py,/home/travis/virtualenv/* -m unittest
   - coveralls

--- a/mlrvalidator/schemas/cross_field_schema.yml
+++ b/mlrvalidator/schemas/cross_field_schema.yml
@@ -17,22 +17,26 @@ altitudeMethodCode:
 altitudeAccuracyValue:
     reciprocal_dependency: [altitude]
 primaryUseOfSite:
-    valid_site_use_cd: True
+    unique_use_value: [secondaryUseOfSite, tertiaryUseOfSiteCode]
 secondaryUseOfSite:
-    valid_site_use_cd: True
+    unique_use_value: [primaryUseOfSite, tertiaryUseOfSiteCode]
+    not_empty_dependency: [primaryUseOfSite]
 tertiaryUseOfSiteCode:
-    valid_site_use_cd: True
+    unique_use_value: [primaryUseOfSite, secondaryUseOfSite]
+    not_empty_dependency: [primaryUseOfSite, secondaryUseOfSite]
 primaryUseOfWaterCode:
-    valid_water_use_cd: True
+    unique_use_value: [secondaryUseOfWaterCode, tertiaryUseOfWaterCode]
 secondaryUseOfWaterCode:
-    valid_water_use_cd: True
+    unique_use_value: [primaryUseOfWaterCode, tertiaryUseOfWaterCode]
+    not_empty_dependency: [primaryUseOfWaterCode]
 tertiaryUseOfWaterCode:
-    valid_water_use_cd: True
+    unique_use_value: [primaryUseOfWaterCode, secondaryUseOfWaterCode]
+    not_empty_dependency: [primaryUseOfWaterCode, secondaryUseOfWaterCode]
 firstConstructionDate:
-    valid_const_inv_dts: True
+    construction_before_inventory: True
 siteEstablishmentDate:
-    valid_const_inv_dts: True
+    construction_before_inventory: True
 holeDepth:
-    valid_well_hole_depths: True
+    check_well_hole_depths: True
 wellDepth:
-    valid_well_hole_depths: True
+    check_well_hole_depths: True

--- a/mlrvalidator/schemas/cross_field_schema.yml
+++ b/mlrvalidator/schemas/cross_field_schema.yml
@@ -1,19 +1,21 @@
 latitude:
-    valid_lat_long: True
+    reciprocal_dependency: [longitude, coordinateAccuracyCode, coordinateDatumCode, coordinateMethodCode]
 longitude:
-    valid_lat_long: True
+    reciprocal_dependency: [latitude, coordinateAccuracyCode, coordinateDatumCode, coordinateMethodCode]
 coordinateAccuracyCode:
-    valid_coord_acy_cd: True
+    reciprocal_dependency: [latitude, longitude]
 coordinateDatumCode:
-    valid_coord_datum_cd: True
+    reciprocal_dependency: [latitude, longitude]
 coordinateMethodCode:
-    valid_coord_meth_cd: True
+    reciprocal_dependency: [latitude, longitude]
+altitude:
+    reciprocal_dependency: [altitudeDatumCode, altitudeMethodCode, altitudeAccuracyValue]
 altitudeDatumCode:
-    valid_alt_datum_cd: True
+    reciprocal_dependency: [altitude]
 altitudeMethodCode:
-    valid_alt_meth_cd: True
+    reciprocal_dependency: [altitude]
 altitudeAccuracyValue:
-    valid_alt_acy_va: True
+    reciprocal_dependency: [altitude]
 primaryUseOfSite:
     valid_site_use_cd: True
 secondaryUseOfSite:

--- a/mlrvalidator/tests/test_services.py
+++ b/mlrvalidator/tests/test_services.py
@@ -30,8 +30,8 @@ class AddValidateTransactionTestCase(TestCase):
                                     content_type='application/json',
                                     data=json.dumps(self.location))
         self.assertEqual(response.status_code, 200)
-        merror_validator.validate.assert_called_with(self.location.get('ddotLocation'))
-        mwarning_validator.validate.assert_called_with(self.location.get('ddotLocation'))
+        merror_validator.validate.assert_called_with(self.location.get('ddotLocation'), {}, update=False)
+        mwarning_validator.validate.assert_called_with(self.location.get('ddotLocation'), update=False)
         resp_data = json.loads(response.data)
         self.assertEqual(len(resp_data), 1)
         self.assertEqual({'validation_passed_message': 'Validations Passed'}, resp_data)
@@ -79,3 +79,14 @@ class AddValidateTransactionTestCase(TestCase):
         self.assertEqual(len(resp_data), 2)
         self.assertIn('warning_message', resp_data)
         self.assertIn('fatal_error_message', resp_data)
+
+    def test_transaction_with_missing_keys(self, merror_validator, mwarning_validator):
+        response = self.app_client.post('/validators/add',
+                                        content_type='application/json',
+                                        data=json.dumps({'ddotLocation': {}})
+                                        )
+        self.assertEqual(response.status_code, 400)
+        response = self.app_client.post('/validators/add',
+                                        content_type='application/json',
+                                        data=json.dumps({'existingLocation': {}})
+                                        )

--- a/mlrvalidator/validators/cross_field_validator.py
+++ b/mlrvalidator/validators/cross_field_validator.py
@@ -17,7 +17,7 @@ class CrossFieldValidator(Validator):
         all values for fields in dependent_list are empty
 
         The rule's arguments are validated against this schema:
-        {'type': 'list', schema: {'type': 'string'}
+        {'type': 'list'}
         """
         for dependent_field in dependent_list:
             dependent_value = self.merged_document.get(dependent_field, '')
@@ -29,93 +29,64 @@ class CrossFieldValidator(Validator):
                 self._error(field, '{0} can not have a value when {1} is null'.format(field, dependent_field))
 
 
-    def _validate_unique_use_value(self, field_to_check, field, value):
+    def _validate_unique_use_value(self, dependent_list, field, value):
         """
         Validates if value is empty or if not empty is different from field_to_check's value
 
         The rule's arguments are validated against this schema:
-        {'type': 'string'}
+        {'type': 'list'}
         """
         field_value = value.strip()
-        field_to_check_value = self.merged_document.get(field_to_check, '').strip()
-        if field_value and (field_value == field_to_check_value):
-            self._error(field, '{0} must not have the same value as {1}'.format(field, field_to_check))
+        for dependent_field in dependent_list:
+            field_to_check_value = self.merged_document.get(dependent_field, '').strip()
+            if field_value and (field_value == field_to_check_value):
+                self._error(field, '{0} must not have the same value as {1}'.format(field, dependent_field))
 
-
-    def _validate_valid_site_use_cd(self, valid_site_use_cd, field, value):
-        # Check that site use codes 1, 2, and 3 have different values if more than one is entered
-        # Check that site use code 2 is null if code 1 is null
-        # Check that site use code 3 is null if code 2 is null
+    def _validate_not_empty_dependency(self, dependent_list, field, value):
         """
+        Validates if value is empty or if value is not empty then validates if field values for fields in
+        dependent_list are not empty.
+
         The rule's arguments are validated against this schema:
-        {'valid_site_use_cd': True}
+        {'type': 'list'}
         """
-        if valid_site_use_cd:
-            if self.document['primaryUseOfSite'] and self.document['secondaryUseOfSite']:
-                if self.document['primaryUseOfSite'] == self.document['secondaryUseOfSite']:
-                    return self._error(field,
-                                       "Site use codes 1, 2, and 3 must have different values if more than one is entered")
-                if self.document['tertiaryUseOfSiteCode']:
-                    if (self.document['primaryUseOfSite'] == self.document['tertiaryUseOfSiteCode']
-                        or self.document['secondaryUseOfSite'] == self.document['tertiaryUseOfSiteCode']
-                        ):
-                        return self._error(field,
-                                           "Site use codes 1, 2, and 3 must have different values if more than one is entered")
-            if not self.document['primaryUseOfSite']:
-                if self.document['secondaryUseOfSite']:
-                    return self._error(field, "Site use code 2 must be null if site use code 1 is null")
-                if self.document['tertiaryUseOfSiteCode']:
-                    return self._error(field, "Site use code 3 must be null if site use code 1 is null")
-            if not self.document['secondaryUseOfSite']:
-                if self.document['tertiaryUseOfSiteCode']:
-                    return self._error(field, "Site use code 3 must be null if site use code 2 is null")
+        field_value = value.strip()
+        if field_value:
+            for dependent_field in dependent_list:
+                if not self.merged_document.get(dependent_field, '').strip():
+                    self._error(field, '{0} can\'t have a value if {1} is empty'.format(field, dependent_field))
 
-    def _validate_valid_water_use_cd(self, valid_water_use_cd, field, value):
-        # Check that water use codes 1, 2, and 3 have different values if more than one is entered
-        # Check that water use code 2 is null if code 1 is null
-        # Check that water use code 3 is null if code 2 is null
-        """
-        The rule's arguments are validated against this schema:
-        {'valid_water_use_cd': True}
-        """
-        if valid_water_use_cd:
-            if self.document['primaryUseOfWaterCode'] and self.document['secondaryUseOfWaterCode']:
-                if self.document['primaryUseOfWaterCode'] == self.document['secondaryUseOfWaterCode']:
-                    return self._error(field,
-                                       "Water use codes 1, 2, and 3 must have different values if more than one is entered")
-                if self.document['tertiaryUseOfWaterCode']:
-                    if (self.document['primaryUseOfWaterCode'] == self.document['tertiaryUseOfWaterCode']
-                        or self.document['secondaryUseOfWaterCode'] == self.document['tertiaryUseOfWaterCode']
-                        ):
-                        return self._error(field,
-                                           "Water use codes 1, 2, and 3 must have different values if more than one is entered")
-            if not self.document['primaryUseOfWaterCode']:
-                if self.document['secondaryUseOfWaterCode']:
-                    return self._error(field, "Water use code 2 must be null if water use code 1 is null")
-                if self.document['tertiaryUseOfWaterCode']:
-                    return self._error(field, "Water use code 3 must be null if water use code 1 is null")
-            if not self.document['secondaryUseOfWaterCode']:
-                if self.document['tertiaryUseOfWaterCode']:
-                    return self._error(field, "Water use code 3 must be null if water use code 2 is null")
 
-    def _validate_valid_const_inv_dts(self, valid_const_inv_dts, field, value):
-        # Check that construction_dt is not > inventory_dt
+    def _validate_construction_before_inventory(self, check_const_inv_dts, field, value):
         """
+        Check that construction_dt is not > inventory_dt if both exist.
+        Note that since dates can be partial, it is assumed that partial construction dates start on first of the
+        year or first of the month. Inventory dates are assumed to be on the last day of the year or month.
+        In practice, we don't see partial inventory dates. We are doing just a string compare rather than
+        translating to actual dates which works as long as the dates are valid.
+
         The rule's arguments are validated against this schema:
-        {'const_inv_dts': True}
+        {'type': 'boolean'}
          """
-        if valid_const_inv_dts:
-            if self.document['firstConstructionDate'] and self.document['siteEstablishmentDate']:
-                if self.document['firstConstructionDate'] > self.document['siteEstablishmentDate']:
-                    return self._error(field, "Construction date cannot be more recent than inventory date")
+        if check_const_inv_dts:
+            construction_date = self.merged_document.get('firstConstructionDate', '').strip()
+            inventory_date = self.merged_document.get('siteEstablishmentDate', '').strip()
+            if (construction_date and inventory_date) and (construction_date > inventory_date):
+                return self._error(field, "firstConstructionDate cannot be more recent than siteEstablishmnetDate")
 
-    def _validate_valid_well_hole_depths(self, valid_well_hole_depths, field, value):
-        # Check that well depth is not > hole depth
+    def _validate_check_well_hole_depths(self, check_well_hole_depths, field, value):
         """
+        Check that well depth is not > hole depth when both are not empty
+
         The rule's arguments are validated against this schema:
-        {'well_hole_depths': True}
+        {'type': 'boolean'}
          """
-        if valid_well_hole_depths:
-            if self.document['wellDepth'] and self.document['holeDepth']:
-                if self.document['wellDepth'] > self.document['holeDepth']:
-                    return self._error(field, "Well depth cannot be greater than hole depth")
+        if check_well_hole_depths:
+            try:
+                hole_depth = float(self.merged_document.get('holeDepth', '').strip())
+                well_depth = float(self.merged_document.get('wellDepth', '').strip())
+            except ValueError:
+                pass
+            else:
+                if (hole_depth and well_depth) and (well_depth > hole_depth):
+                    return self._error(field, "wellDepth cannot be greater than holeDepth")

--- a/mlrvalidator/validators/cross_field_validator.py
+++ b/mlrvalidator/validators/cross_field_validator.py
@@ -1,5 +1,5 @@
-from cerberus import Validator
 
+from cerberus import Validator
 
 class CrossFieldValidator(Validator):
 
@@ -90,3 +90,4 @@ class CrossFieldValidator(Validator):
             else:
                 if (hole_depth and well_depth) and (well_depth > hole_depth):
                     return self._error(field, "wellDepth cannot be greater than holeDepth")
+

--- a/mlrvalidator/validators/error_validator.py
+++ b/mlrvalidator/validators/error_validator.py
@@ -19,11 +19,11 @@ class ErrorValidator:
         self.cross_field_validator = CrossFieldValidator(cross_field_schema, allow_unknown=True)
         self._errors = defaultdict(list)
 
-    def validate(self, document, update=False):
-        valid_single_field = self.single_field_validator.validate(document, update=update)
-        valid_reference = self.reference_validator.validate(document, update=update)
-        valid_site_type = self.site_type_cross_field_validator.validate(document, update=update)
-        valid_cross_field = self.cross_field_validator.validate(document, update=update)
+    def validate(self, ddot_location, existing_location, update=False):
+        valid_single_field = self.single_field_validator.validate(ddot_location, update=update)
+        valid_reference = self.reference_validator.validate(ddot_location, update=update)
+        valid_site_type = self.site_type_cross_field_validator.validate(ddot_location, update=update)
+        valid_cross_field = self.cross_field_validator.validate(ddot_location, update=update)
 
         self._errors = defaultdict(list)
         all_errors = chain(self.single_field_validator.errors.items(),

--- a/mlrvalidator/validators/error_validator.py
+++ b/mlrvalidator/validators/error_validator.py
@@ -23,7 +23,7 @@ class ErrorValidator:
         valid_single_field = self.single_field_validator.validate(ddot_location, update=update)
         valid_reference = self.reference_validator.validate(ddot_location, update=update)
         valid_site_type = self.site_type_cross_field_validator.validate(ddot_location, update=update)
-        valid_cross_field = self.cross_field_validator.validate(ddot_location, update=update)
+        valid_cross_field = self.cross_field_validator.validate(ddot_location, existing_location, update=update)
 
         self._errors = defaultdict(list)
         all_errors = chain(self.single_field_validator.errors.items(),

--- a/mlrvalidator/validators/tests/test_cross_field_validator.py
+++ b/mlrvalidator/validators/tests/test_cross_field_validator.py
@@ -2,8 +2,6 @@ from unittest import TestCase
 from ..cross_field_validator import CrossFieldValidator
 from mlrvalidator.schema import cross_field_schema
 
-cross_field_validator = CrossFieldValidator(cross_field_schema)
-cross_field_validator.allow_unknown = True
 
 class CrossFieldValidatorReciprocalDependencyTestCase(TestCase):
     def setUp(self):
@@ -61,291 +59,139 @@ class CrossFieldValidatorReciprocalDependencyTestCase(TestCase):
 
 
 class CrossFieldValidatorUniqueUseTestCase(TestCase):
+
     def setUp(self):
-        self.validator = CrossFieldValidator(allow_unknown=True, schema={'field1': {'unique_use_value': 'field2'}})
+        self.validator = CrossFieldValidator(allow_unknown=True, schema={'field1': {'unique_use_value': ['field2', 'field3']}})
 
     def test_valid_unique_use(self):
-        self.assertTrue(self.validator.validate({'field1': 'A', 'field2': 'B'}, {}))
+        self.assertTrue(self.validator.validate({'field1': 'A', 'field2': 'B', 'field3' : 'B'}, {}))
         self.assertTrue(self.validator.validate({'field1': 'A', 'field2': ' '}, {}))
         self.assertTrue(self.validator.validate({'field1': ' ', 'field2': 'B'}, {}))
         self.assertTrue(self.validator.validate({'field1': ' '}, {}))
 
     def test_not_unique_use(self):
         self.assertFalse(self.validator.validate({'field1': 'A', 'field2': 'A'}, {}))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field2': 'A', 'field3': 'A'}, {}))
+        self.assertEqual(len(self.validator.errors.get('field1')), 2)
+
 
     def test_valid_unique_use_on_update(self):
-        self.assertTrue(self.validator.validate({'field1': 'A'}, {'field2': 'B'}, update=True))
+        self.assertTrue(self.validator.validate({'field1': 'A', 'field3': 'B'}, {'field2': 'B'}, update=True))
         self.assertTrue(self.validator.validate({'field1': ' '}, {'field2': 'B'}, update=True))
         self.assertTrue(self.validator.validate({'field1': ' '}, {'field2': ' '}, update=True))
 
     def test_not_unique_use_on_update(self):
         self.assertFalse(self.validator.validate({'field1': 'A'}, {'field2': 'A'}, update=True))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field2': 'A'}, {'field3': 'A'}, update=True))
+        self.assertEqual(len(self.validator.errors.get('field1')), 2)
 
 
-
-class ValidateCrossFieldsTestCase(TestCase):
+class CrossFieldValidatorNotEmptyDependencyTestCase(TestCase):
 
     def setUp(self):
-        self.good_data = {
-            'latitude': ' 123456',
-            'longitude': ' 1234556',
-            'coordinateAccuracyCode': '1',
-            'coordinateDatumCode': 'ABIDJAN',
-            'coordinateMethodCode': 'C'
-        }
-        self.good_data2 = {
-            'altitude': '1234',
-            'altitudeDatumCode': 'ASVD02',
-            'altitudeMethodCode': 'A',
-            'altitudeAccuracyValue': '12'
-        }
-        self.good_data3 = {
-            'primaryUseOfSite': 'A',
-            'secondaryUseOfSite': 'C',
-            'tertiaryUseOfSiteCode': 'E'
-        }
-        self.good_data4 = {
-            'primaryUseOfWaterCode': 'A',
-            'secondaryUseOfWaterCode': 'C',
-            'tertiaryUseOfWaterCode': 'E'
-        }
-        self.good_data5 = {
-            'firstConstructionDate': '20000101',
-            'siteEstablishmentDate': '20000102'
-        }
-        self.good_data6 = {
-            'firstConstructionDate': '200001',
-            'siteEstablishmentDate': '200101'
-        }
-        self.good_data7 = {
-            'firstConstructionDate': '2000',
-            'siteEstablishmentDate': '2001'
-        }
-        self.good_data8 = {
-            'wellDepth': '10',
-            'holeDepth': '10'
-        }
-        self.good_data9 = {
-            'wellDepth': '10',
-            'holeDepth': '11'
-        }
-        self.good_data10 = {
-            'wellDepth': '',
-            'holeDepth': '10'
-        }
-        self.good_data11 = {
-            'wellDepth': '10',
-            'holeDepth': ''
-        }
-        self.good_data12 = {
-            'wellDepth': '',
-            'holeDepth': ''
-        }
-        self.bad_data = {
-            'latitude': '',
-            'longitude': '',
-            'coordinateAccuracyCode': '1',
-            'coordinateDatumCode': 'ABIDJAN',
-            'coordinateMethodCode': 'C'
-        }
-        self.bad_data2 = {
-            'latitude': ' 123456',
-            'longitude': '',
-        }
-        self.bad_data3 = {
-            'latitude': '',
-            'longitude': ' 1234556',
-        }
-        self.bad_data4 = {
-            'latitude': ' 123456',
-            'longitude': ' 1234556',
-            'coordinateAccuracyCode': '',
-            'coordinateDatumCode': 'ABIDJAN',
-            'coordinateMethodCode': 'C'
-        }
-        self.bad_data5 = {
-            'latitude': ' 123456',
-            'longitude': ' 1234556',
-            'coordinateAccuracyCode': '1',
-            'coordinateDatumCode': '',
-            'coordinateMethodCode': 'C'
-        }
-        self.bad_data6 = {
-            'latitude': ' 123456',
-            'longitude': ' 1234556',
-            'coordinateAccuracyCode': '1',
-            'coordinateDatumCode': 'ABIDJAN',
-            'coordinateMethodCode': ''
-        }
-        self.bad_data7 = {
-            'latitude': ' 123456',
-            'longitude': ' 1234556',
-            'coordinateAccuracyCode': '',
-            'coordinateDatumCode': '',
-            'coordinateMethodCode': ''
-        }
-        self.bad_data8 = {
-            'altitude': '',
-            'altitudeDatumCode': 'ASVD02',
-            'altitudeAccuracyValue': '12',
-            'altitudeMethodCode': 'A'
-        }
-        self.bad_data9 = {
-            'altitude': '1234',
-            'altitudeDatumCode': '',
-            'altitudeAccuracyValue': '12',
-            'altitudeMethodCode': 'A'
-        }
-        self.bad_data10 = {
-            'altitude': '1234',
-            'altitudeDatumCode': 'ASVD02',
-            'altitudeAccuracyValue': '',
-            'altitudeMethodCode': 'A'
-        }
-        self.bad_data11 = {
-            'altitude': '1234',
-            'altitudeDatumCode': 'ASVD02',
-            'altitudeAccuracyValue': '12',
-            'altitudeMethodCode': ''
-        }
-        self.bad_data12 = {
-            'altitude': '1234',
-            'altitudeDatumCode': '',
-            'altitudeAccuracyValue': '',
-            'altitudeMethodCode': ''
-        }
-        self.bad_data13 = {
-            'primaryUseOfSite': 'A',
-            'secondaryUseOfSite': 'A',
-            'tertiaryUseOfSiteCode': 'A'
-        }
-        self.bad_data14 = {
-            'primaryUseOfSite': 'A',
-            'secondaryUseOfSite': 'A',
-            'tertiaryUseOfSiteCode': 'C'
-        }
-        self.bad_data15 = {
-            'primaryUseOfSite': 'A',
-            'secondaryUseOfSite': 'C',
-            'tertiaryUseOfSiteCode': 'A'
-        }
-        self.bad_data16 = {
-            'primaryUseOfSite': 'C',
-            'secondaryUseOfSite': 'A',
-            'tertiaryUseOfSiteCode': 'A'
-        }
-        self.bad_data17 = {
-            'primaryUseOfSite': '',
-            'secondaryUseOfSite': 'C',
-            'tertiaryUseOfSiteCode': 'E'
-        }
-        self.bad_data18 = {
-            'primaryUseOfSite': 'A',
-            'secondaryUseOfSite': '',
-            'tertiaryUseOfSiteCode': 'E'
-        }
-        self.bad_data19 = {
-            'primaryUseOfSite': '',
-            'secondaryUseOfSite': '',
-            'tertiaryUseOfSiteCode': 'E'
-        }
-        self.bad_data20 = {
-            'primaryUseOfWaterCode': 'A',
-            'secondaryUseOfWaterCode': 'A',
-            'tertiaryUseOfWaterCode': 'A'
-        }
-        self.bad_data21 = {
-            'primaryUseOfWaterCode': 'A',
-            'secondaryUseOfWaterCode': 'A',
-            'tertiaryUseOfWaterCode': 'C'
-        }
-        self.bad_data22 = {
-            'primaryUseOfWaterCode': 'A',
-            'secondaryUseOfWaterCode': 'C',
-            'tertiaryUseOfWaterCode': 'A'
-        }
-        self.bad_data23 = {
-            'primaryUseOfWaterCode': 'C',
-            'secondaryUseOfWaterCode': 'A',
-            'tertiaryUseOfWaterCode': 'A'
-        }
-        self.bad_data24 = {
-            'primaryUseOfWaterCode': '',
-            'secondaryUseOfWaterCode': 'C',
-            'tertiaryUseOfWaterCode': 'E'
-        }
-        self.bad_data25 = {
-            'primaryUseOfWaterCode': 'A',
-            'secondaryUseOfWaterCode': '',
-            'tertiaryUseOfWaterCode': 'E'
-        }
-        self.bad_data26 = {
-            'primaryUseOfWaterCode': '',
-            'secondaryUseOfWaterCode': '',
-            'tertiaryUseOfWaterCode': 'E'
-        }
-        self.bad_data27 = {
-            'firstConstructionDate': '20000102',
-            'siteEstablishmentDate': '20000101'
-        }
-        self.bad_data28 = {
-            'firstConstructionDate': '200002',
-            'siteEstablishmentDate': '200001'
-        }
-        self.bad_data29 = {
-            'firstConstructionDate': '2001',
-            'siteEstablishmentDate': '2000'
-        }
-        self.bad_data30 = {
-            'wellDepth': '11',
-            'holeDepth': '10'
-        }
+        self.validator = CrossFieldValidator(allow_unknown=True, schema={'field1': {'not_empty_dependency' : ['field2', 'field3']}})
 
-    def test_validate_ok(self):
-        self.assertTrue(cross_field_validator.validate(self.good_data, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data2, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data3, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data4, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data5, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data6, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data7, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data8, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data9, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data10, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data11, {}))
-        self.assertTrue(cross_field_validator.validate(self.good_data12, {}))
+    def test_valid_not_empty_dependency(self):
+        self.assertTrue(self.validator.validate({'field1' : 'A', 'field2': 'B', 'field3': 'C'}, {}))
+        self.assertTrue(self.validator.validate({'field1': ' ', 'field2': 'B', 'field3': 'C'}, {}))
+
+    def test_invalid_not_empty_dependency(self):
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field2': ' ', 'field3': 'C'}, {}))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field2': 'B'}, {}))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field3': ' '}, {}))
+        self.assertEqual(len(self.validator.errors.get('field1')), 2)
+
+    def test_valid_not_empty_dependency_on_update(self):
+        self.assertTrue(self.validator.validate({'field1' : 'A', 'field2': 'B', }, {'field3': 'C'}, update=True))
+        self.assertTrue(self.validator.validate({'field1' : ' ', 'field2': 'B', }, {'field3': 'C'}, update=True))
+
+    def test_invalid_not_empty_dependency(self):
+        self.assertFalse(self.validator.validate({'field1': 'A'}, {'field3': 'C'}, update=True))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A', 'field2': 'B'}, {'field3': ' '}, update=True))
+        self.assertEqual(len(self.validator.errors.get('field1')), 1)
+
+        self.assertFalse(self.validator.validate({'field1': 'A'}, {'field2': ' ', 'field3': ' '}, update=True))
+        self.assertEqual(len(self.validator.errors.get('field1')), 2)
 
 
-    def test_validate_not_ok(self):
-        self.assertFalse(cross_field_validator.validate(self.bad_data, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data2, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data3, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data4, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data5, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data6, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data7, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data8, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data9, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data10, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data11, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data12, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data13, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data14, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data15, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data16, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data17, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data18, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data19, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data20, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data21, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data22, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data23, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data24, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data25, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data26, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data27, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data28, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data29, {}))
-        self.assertFalse(cross_field_validator.validate(self.bad_data30, {}))
+class CrossFieldValidatorContructionBeforeInventoryTestCase(TestCase):
+
+    def setUp(self):
+        self.validator = CrossFieldValidator(allow_unknown=True,
+                                             schema={'firstConstructionDate' : {'construction_before_inventory': True},
+                                                     'siteEstablishmentDate' : {'construction_before_inventory': True}})
+
+    def test_valid_date(self):
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '20100415', 'siteEstablishmentDate': '20100416'}, {}))
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '201004', 'siteEstablishmentDate': '20100416'}, {}))
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '2010', 'siteEstablishmentDate': '20100416'}, {}))
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '2010', 'siteEstablishmentDate': '201004'}, {}))
+
+    def test_with_empty_date(self):
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '20100415'}, {}))
+        self.assertTrue(self.validator.validate({'siteEstablishmentDate': '20100415'}, {}))
+
+    def test_with_invalid_dates(self):
+        self.assertFalse(self.validator.validate({'firstConstructionDate': '20100415', 'siteEstablishmentDate': '20100414'}, {}))
+        self.assertFalse(self.validator.validate({'firstConstructionDate': '201004', 'siteEstablishmentDate': '20100315'}, {}))
+        self.assertFalse(self.validator.validate({'firstConstructionDate': '2010', 'siteEstablishmentDate': '20091231'}, {}))
+
+    def test_valid_date_with_update(self):
+        self.assertFalse(self.validator.validate({'firstConstructionDate': '201004'}, {'siteEstablishmentDate': '20100315'}, update=True))
+        self.assertFalse(self.validator.validate({'siteEstablishmentDate': '20100315'}, {'firstConstructionDate': '201004'}, update=True))
+
+    def test_with_empty_date_update(self):
+        self.assertTrue(self.validator.validate({'firstConstructionDate': '20100415'}, {'siteEstablishmentDate': ''}, update=True))
+        self.assertTrue(self.validator.validate({'siteEstablishmentDate': '20100415'}, {'firstConstructionDate': ''}, update=True))
+
+    def test_with_invalid_dates_update(self):
+        self.assertFalse(self.validator.validate({'firstConstructionDate': '20100415'}, {'siteEstablishmentDate': '20100414'}, update=True))
+        self.assertFalse(self.validator.validate({'siteEstablishmentDate': '20100315'}, {'firstConstructionDate': '201004'}, update=True))
+
+class CrossFieldValidatorCheckWellHoleDepthTestCase(TestCase):
+
+    def setUp(self):
+        self.validator = CrossFieldValidator(allow_unknown=True,
+                                             schema={'wellDepth' : {'check_well_hole_depths': True},
+                                                     'holeDepth' : {'check_well_hole_depths': True}})
+
+    def test_valid_depths(self):
+        self.assertTrue(self.validator.validate({'wellDepth': '1234', 'holeDepth': '11234'},  {}))
+        self.assertTrue(self.validator.validate({'wellDepth': '9', 'holeDepth': '10'}, {}))
+
+    def test_with_empty_depths(self):
+        self.assertTrue(self.validator.validate({'wellDepth': '1234'}, {}))
+        self.assertTrue(self.validator.validate({'holeDepth': '11234'}, {}))
+        self.assertTrue(self.validator.validate({'wellDepth': ' ', 'holeDepth': ' '}, {}))
+        self.assertTrue(self.validator.validate({'wellDepth' : '1234', 'holeDepth': 'A'}, {}))
+
+    def test_invalid_depths(self):
+        self.assertFalse(self.validator.validate({'wellDepth': '11234', 'holeDepth': '1234'}, {}))
+        self.assertFalse(self.validator.validate({'wellDepth': '10', 'holeDepth': '9'}, {}))
+
+    def test_valid_depths_update(self):
+        self.assertTrue(self.validator.validate({'wellDepth': '1234'}, {'holeDepth': '11234'}, update=True))
+        self.assertTrue(self.validator.validate({'holeDepth': '10'}, {'wellDepth': '9'}, update=True))
+
+    def test_with_empty_depths_update(self):
+        self.assertTrue(self.validator.validate({'wellDepth': '1234'}, {'holeDepth': '   '}, update=True))
+        self.assertTrue(self.validator.validate({'holeDepth': '11234'}, {'wellDepth': '   '}, update=True))
+        self.assertTrue(self.validator.validate({'wellDepth': ' ', 'holeDepth': ' '}, {}, update=True))
+        self.assertTrue(self.validator.validate({'wellDepth': '1234', 'holeDepth': 'A'}, {}, update=True))
+
+    def test_invalid_depths_update(self):
+        self.assertFalse(self.validator.validate({'wellDepth': '11234'}, {'holeDepth': '1234'}, update=True))
+        self.assertFalse(self.validator.validate({'holeDepth': '9'}, {'wellDepth': '10'}))
+
 
 

--- a/mlrvalidator/validators/tests/test_cross_field_validator.py
+++ b/mlrvalidator/validators/tests/test_cross_field_validator.py
@@ -54,7 +54,7 @@ class CrossFieldValidatorReciprocalDependencyTestCase(TestCase):
 
 
     def test_update_valid_field_dependency(self):
-        self.assertTrue(self.validator.validate({'field1': '11111', 'field2': '22222'}, {'field3': 'B'}, update=True))
+        self.assertTrue(self.validator.validate({'field1': '11111', 'field2': '2222'}, {'field2': '    ', 'field3': 'B'}, update=True))
         self.assertTrue(self.validator.validate({'field1': '11111', 'field3': '22222'}, {'field2' : 'A'}, update=True))
 
 

--- a/mlrvalidator/validators/tests/test_error_validator.py
+++ b/mlrvalidator/validators/tests/test_error_validator.py
@@ -136,11 +136,6 @@ class ErrorValidatorErrorsTestCase(TestCase):
         self.assertEqual(len(validator.errors), 2)
 
 
-class ErrorValidatorLatitudeTestCase(TestCase):
-
-    def latitude_without_longitude_is_invalid(self):
-        self.assertFalse(self.validator.validate({'latitude': ' 0400000'}, {}))
-
 
 
 

--- a/mlrvalidator/validators/tests/test_error_validator.py
+++ b/mlrvalidator/validators/tests/test_error_validator.py
@@ -25,7 +25,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {}
 
         validator = ErrorValidator()
-        result = validator.validate({'A' : 'This', 'B' : 'That'})
+        result = validator.validate({'A' : 'This', 'B' : 'That'}, {})
 
         self.assertTrue(result)
         self.assertEqual(len(validator.errors), 0)
@@ -46,7 +46,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {}
 
         validator = ErrorValidator()
-        result = validator.validate({'A': 'This', 'B': 'That'})
+        result = validator.validate({'A': 'This', 'B': 'That'}, {})
 
         self.assertFalse(result)
         self.assertEqual(len(validator.errors), 1)
@@ -67,7 +67,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {}
 
         validator = ErrorValidator()
-        result = validator.validate({'A': 'This', 'B': 'That'})
+        result = validator.validate({'A': 'This', 'B': 'That'}, {})
 
         self.assertFalse(result)
         self.assertEqual(len(validator.errors), 1)
@@ -88,7 +88,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {}
 
         validator = ErrorValidator()
-        result = validator.validate({'A': 'This', 'B': 'That'})
+        result = validator.validate({'A': 'This', 'B': 'That'}, {})
 
         self.assertFalse(result)
         self.assertEqual(len(validator.errors), 1)
@@ -109,7 +109,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {'A': ['Bad']}
 
         validator = ErrorValidator()
-        result = validator.validate({'A': 'This', 'B': 'That'})
+        result = validator.validate({'A': 'This', 'B': 'That'}, {})
 
         self.assertFalse(result)
         self.assertEqual(len(validator.errors), 1)
@@ -130,7 +130,7 @@ class ErrorValidatorErrorsTestCase(TestCase):
         mcrossfield.errors = {'A': ['Invalid']}
 
         validator = ErrorValidator()
-        result = validator.validate({'A': 'This', 'B': 'That'})
+        result = validator.validate({'A': 'This', 'B': 'That'}, {})
 
         self.assertFalse(result)
         self.assertEqual(len(validator.errors), 2)

--- a/mlrvalidator/validators/tests/test_error_validator.py
+++ b/mlrvalidator/validators/tests/test_error_validator.py
@@ -136,6 +136,12 @@ class ErrorValidatorErrorsTestCase(TestCase):
         self.assertEqual(len(validator.errors), 2)
 
 
+class ErrorValidatorLatitudeTestCase(TestCase):
+
+    def latitude_without_longitude_is_invalid(self):
+        self.assertFalse(self.validator.validate({'latitude': ' 0400000'}, {}))
+
+
 
 
 

--- a/mlrvalidator/validators/tests/test_error_validator_with_schema.py
+++ b/mlrvalidator/validators/tests/test_error_validator_with_schema.py
@@ -3,6 +3,12 @@ from unittest import TestCase
 
 from ..error_validator import ErrorValidator
 
+class ErrorValidatorLatitudeTestCase(TestCase):
+    #TODO: fill in with additional tests for latitude. Ideally each field that has validations would have a separate test case.
+
+    def latitude_without_longitude_is_invalid(self):
+        self.assertFalse(self.validator.validate({'latitude': ' 0400000'}, {}))
+
 class ValidateCrossFieldsTestCase(TestCase):
 
     #TODO: Break this up so that a test case tests a fields validation rules. Below is the cross field validation schema tests

--- a/mlrvalidator/validators/tests/test_error_validator_with_schema.py
+++ b/mlrvalidator/validators/tests/test_error_validator_with_schema.py
@@ -1,0 +1,275 @@
+
+from unittest import TestCase
+
+from ..error_validator import ErrorValidator
+
+class ValidateCrossFieldsTestCase(TestCase):
+
+    #TODO: Break this up so that a test case tests a fields validation rules. Below is the cross field validation schema tests
+    #TODO: Add needed tests for all validations not just cross field.
+    def setUp(self):
+        self.validator = ErrorValidator()
+        self.good_data = {
+            'latitude': ' 123456',
+            'longitude': ' 1234556',
+            'coordinateAccuracyCode': '1',
+            'coordinateDatumCode': 'ABIDJAN',
+            'coordinateMethodCode': 'C'
+        }
+        self.good_data2 = {
+            'altitude': '1234',
+            'altitudeDatumCode': 'ASVD02',
+            'altitudeMethodCode': 'A',
+            'altitudeAccuracyValue': '12'
+        }
+        self.good_data3 = {
+            'primaryUseOfSite': 'A',
+            'secondaryUseOfSite': 'C',
+            'tertiaryUseOfSiteCode': 'E'
+        }
+        self.good_data4 = {
+            'primaryUseOfWaterCode': 'A',
+            'secondaryUseOfWaterCode': 'C',
+            'tertiaryUseOfWaterCode': 'E'
+        }
+        self.good_data5 = {
+            'firstConstructionDate': '20000101',
+            'siteEstablishmentDate': '20000102'
+        }
+        self.good_data6 = {
+            'firstConstructionDate': '200001',
+            'siteEstablishmentDate': '200101'
+        }
+        self.good_data7 = {
+            'firstConstructionDate': '2000',
+            'siteEstablishmentDate': '2001'
+        }
+        self.good_data8 = {
+            'wellDepth': '10',
+            'holeDepth': '10'
+        }
+        self.good_data9 = {
+            'wellDepth': '10',
+            'holeDepth': '11'
+        }
+        self.good_data10 = {
+            'wellDepth': '',
+            'holeDepth': '10'
+        }
+        self.good_data11 = {
+            'wellDepth': '10',
+            'holeDepth': ''
+        }
+        self.good_data12 = {
+            'wellDepth': '',
+            'holeDepth': ''
+        }
+        self.bad_data = {
+            'latitude': '',
+            'longitude': '',
+            'coordinateAccuracyCode': '1',
+            'coordinateDatumCode': 'ABIDJAN',
+            'coordinateMethodCode': 'C'
+        }
+        self.bad_data2 = {
+            'latitude': ' 123456',
+            'longitude': '',
+        }
+        self.bad_data3 = {
+            'latitude': '',
+            'longitude': ' 1234556',
+        }
+        self.bad_data4 = {
+            'latitude': ' 123456',
+            'longitude': ' 1234556',
+            'coordinateAccuracyCode': '',
+            'coordinateDatumCode': 'ABIDJAN',
+            'coordinateMethodCode': 'C'
+        }
+        self.bad_data5 = {
+            'latitude': ' 123456',
+            'longitude': ' 1234556',
+            'coordinateAccuracyCode': '1',
+            'coordinateDatumCode': '',
+            'coordinateMethodCode': 'C'
+        }
+        self.bad_data6 = {
+            'latitude': ' 123456',
+            'longitude': ' 1234556',
+            'coordinateAccuracyCode': '1',
+            'coordinateDatumCode': 'ABIDJAN',
+            'coordinateMethodCode': ''
+        }
+        self.bad_data7 = {
+            'latitude': ' 123456',
+            'longitude': ' 1234556',
+            'coordinateAccuracyCode': '',
+            'coordinateDatumCode': '',
+            'coordinateMethodCode': ''
+        }
+        self.bad_data8 = {
+            'altitude': '',
+            'altitudeDatumCode': 'ASVD02',
+            'altitudeAccuracyValue': '12',
+            'altitudeMethodCode': 'A'
+        }
+        self.bad_data9 = {
+            'altitude': '1234',
+            'altitudeDatumCode': '',
+            'altitudeAccuracyValue': '12',
+            'altitudeMethodCode': 'A'
+        }
+        self.bad_data10 = {
+            'altitude': '1234',
+            'altitudeDatumCode': 'ASVD02',
+            'altitudeAccuracyValue': '',
+            'altitudeMethodCode': 'A'
+        }
+        self.bad_data11 = {
+            'altitude': '1234',
+            'altitudeDatumCode': 'ASVD02',
+            'altitudeAccuracyValue': '12',
+            'altitudeMethodCode': ''
+        }
+        self.bad_data12 = {
+            'altitude': '1234',
+            'altitudeDatumCode': '',
+            'altitudeAccuracyValue': '',
+            'altitudeMethodCode': ''
+        }
+        self.bad_data13 = {
+            'primaryUseOfSite': 'A',
+            'secondaryUseOfSite': 'A',
+            'tertiaryUseOfSiteCode': 'A'
+        }
+        self.bad_data14 = {
+            'primaryUseOfSite': 'A',
+            'secondaryUseOfSite': 'A',
+            'tertiaryUseOfSiteCode': 'C'
+        }
+        self.bad_data15 = {
+            'primaryUseOfSite': 'A',
+            'secondaryUseOfSite': 'C',
+            'tertiaryUseOfSiteCode': 'A'
+        }
+        self.bad_data16 = {
+            'primaryUseOfSite': 'C',
+            'secondaryUseOfSite': 'A',
+            'tertiaryUseOfSiteCode': 'A'
+        }
+        self.bad_data17 = {
+            'primaryUseOfSite': '',
+            'secondaryUseOfSite': 'C',
+            'tertiaryUseOfSiteCode': 'E'
+        }
+        self.bad_data18 = {
+            'primaryUseOfSite': 'A',
+            'secondaryUseOfSite': '',
+            'tertiaryUseOfSiteCode': 'E'
+        }
+        self.bad_data19 = {
+            'primaryUseOfSite': '',
+            'secondaryUseOfSite': '',
+            'tertiaryUseOfSiteCode': 'E'
+        }
+        self.bad_data20 = {
+            'primaryUseOfWaterCode': 'A',
+            'secondaryUseOfWaterCode': 'A',
+            'tertiaryUseOfWaterCode': 'A'
+        }
+        self.bad_data21 = {
+            'primaryUseOfWaterCode': 'A',
+            'secondaryUseOfWaterCode': 'A',
+            'tertiaryUseOfWaterCode': 'C'
+        }
+        self.bad_data22 = {
+            'primaryUseOfWaterCode': 'A',
+            'secondaryUseOfWaterCode': 'C',
+            'tertiaryUseOfWaterCode': 'A'
+        }
+        self.bad_data23 = {
+            'primaryUseOfWaterCode': 'C',
+            'secondaryUseOfWaterCode': 'A',
+            'tertiaryUseOfWaterCode': 'A'
+        }
+        self.bad_data24 = {
+            'primaryUseOfWaterCode': '',
+            'secondaryUseOfWaterCode': 'C',
+            'tertiaryUseOfWaterCode': 'E'
+        }
+        self.bad_data25 = {
+            'primaryUseOfWaterCode': 'A',
+            'secondaryUseOfWaterCode': '',
+            'tertiaryUseOfWaterCode': 'E'
+        }
+        self.bad_data26 = {
+            'primaryUseOfWaterCode': '',
+            'secondaryUseOfWaterCode': '',
+            'tertiaryUseOfWaterCode': 'E'
+        }
+        self.bad_data27 = {
+            'firstConstructionDate': '20000102',
+            'siteEstablishmentDate': '20000101'
+        }
+        self.bad_data28 = {
+            'firstConstructionDate': '200002',
+            'siteEstablishmentDate': '200001'
+        }
+        self.bad_data29 = {
+            'firstConstructionDate': '2001',
+            'siteEstablishmentDate': '2000'
+        }
+        self.bad_data30 = {
+            'wellDepth': '11',
+            'holeDepth': '10'
+        }
+
+    def test_validate_ok(self):
+        self.assertTrue(self.validator.validate(self.good_data, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data2, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data3, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data4, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data5, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data6, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data7, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data8, {}, update=True))
+        self.assertTrue(self.validator.validate(self.good_data9, {}, update=True))
+        #TODO: Fix validate_type_numeric to return true for empty strings and strings with all blanks.
+        #self.validator.validate(self.good_data10, {}, update=True)
+        #self.assertTrue(self.validator.validate(self.good_data11, {}, update=True))
+        #self.assertTrue(self.validator.validate(self.good_data12, {}, update=True))
+
+
+    def test_validate_not_ok(self):
+        self.assertFalse(self.validator.validate(self.bad_data, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data2, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data3, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data4, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data5, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data6, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data7, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data8, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data9, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data10, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data11, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data12, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data13, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data14, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data15, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data16, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data17, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data18, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data19, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data20, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data21, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data22, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data23, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data24, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data25, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data26, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data27, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data28, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data29, {}, update=True))
+        self.assertFalse(self.validator.validate(self.bad_data30, {}, update=True))
+
+


### PR DESCRIPTION
I ended up reworking the cross reference validations to remove duplicated code. The tests for the cross_reference_validator are now true unit tests and don't use the schema yaml file. I moved those tests into test_error_validator_with_schema.py with several todos and a couple of commented out tests that don't work at the moment.

Still need to do site type cross field validations for update but wanted to get this out. Note that the update service still hasn't been implemented