### PR TITLE
Mlr 200

### DIFF
--- a/mlrvalidator/schemas/error_schema.yml
+++ b/mlrvalidator/schemas/error_schema.yml
@@ -66,6 +66,7 @@ countyCode:
     maxlength: 3
 minorCivilDivisionCode:
     maxlength: 5
+    nullable: True
 hydrologicUnitCode:
     maxlength: 16
 basinCode:

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -2284,3 +2284,51 @@ class TertiaryUseOfWaterCodeTestCase(TestCase):
         )
         self.assertIn('tertiaryUseOfWaterCode', validator.errors)
 
+
+class TopographicCodeTestCase(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('topographicCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'topographicCode': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('topographicCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'topographicCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('topographicCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'topographicCode': 'AA'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('topographicCode', validator.errors)
+
+    def test_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'topographicCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('topographicCode', validator.errors)
+
+    def test_not_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'topographicCode': 'Z'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('topographicCode', validator.errors)

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -1,5 +1,5 @@
 
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from app import application
 from ..error_validator import ErrorValidator

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -2387,3 +2387,58 @@ class InstrumentsCode(TestCase):
             update=True
         )
         self.assertIn('instrumentsCode', validator.errors)
+
+
+class DataTypesCode(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('dataTypesCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': '   '},
+            {},
+            update=False
+        )
+        self.assertNotIn('dataTypesCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': 'AION AION AION AION AION AION '},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('dataTypesCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': 'AION AION AION AION AION AION A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('dataTypesCode', validator.errors)
+
+    def test_invalid_characters(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': '  AIONAOIN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('dataTypesCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': '  AIOXAOIN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('dataTypesCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'dataTypesCode': '  AION*AOIN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('dataTypesCode', validator.errors)

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -2226,3 +2226,61 @@ class SecondaryUseOfWaterCodeTestCase(TestCase):
             {'agencyCode': 'USGS ', 'siteNumber': '12345678'}
         )
         self.assertIn('secondaryUseOfWaterCode', validator.errors)
+
+
+class TertiaryUseOfWaterCodeTestCase(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('tertiaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('tertiaryUseOfWaterCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': 'U'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A', 'secondaryUseOfWaterCode': 'B'},
+            update=True
+        )
+        self.assertNotIn('tertiaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': 'UU'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A', 'secondaryUseOfWaterCode': 'B'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfWaterCode', validator.errors)
+
+    def test_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': 'U'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A', 'secondaryUseOfWaterCode': 'B'},
+            update=True
+        )
+        self.assertNotIn('tertiaryUseOfWaterCode', validator.errors)
+
+    def test_not_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': 'V'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A', 'secondaryUseOfWaterCode': 'B'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfWaterCode', validator.errors)
+
+    def test_null_secondary_with_tertiary(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfWaterCode': 'V'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfWaterCode', validator.errors)
+

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -1558,7 +1558,16 @@ class MinorCivilDivisionCodeTestCase(TestCase):
     def test_null_mcd_code(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '55', 'countyCode': '001'},
-            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': None}
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': None},
+            update=True
+        )
+        self.assertNotIn('minorCivilDivisionCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': None, 'countryCode': 'US', 'stateFipsCode': '55',
+             'countyCode': '001'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
         )
         self.assertNotIn('minorCivilDivisionCode', validator.errors)
 
@@ -1566,7 +1575,8 @@ class MinorCivilDivisionCodeTestCase(TestCase):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': '00275'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '55',
-             'countyCode': '001'}
+             'countyCode': '001'},
+            update=True
         )
         self.assertNotIn('minorCivilDivisionCode', validator.errors)
 
@@ -1574,7 +1584,8 @@ class MinorCivilDivisionCodeTestCase(TestCase):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': '00277'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '55',
-             'countyCode': '001'}
+             'countyCode': '001'},
+            update=True
         )
         self.assertIn('minorCivilDivisionCode', validator.errors)
 
@@ -1582,21 +1593,24 @@ class MinorCivilDivisionCodeTestCase(TestCase):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': '00277'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'CN', 'stateFipsCode': '55',
-             'countyCode': '001'}
+             'countyCode': '001'},
+            update=True
         )
         self.assertIn('minorCivilDivisionCode', validator.errors)
 
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': '00277'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '85',
-             'countyCode': '001'}
+             'countyCode': '001'},
+            update=True
         )
         self.assertIn('minorCivilDivisionCode', validator.errors)
 
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'minorCivilDivisionCode': '00277'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '55',
-             'countyCode': '002'}
+             'countyCode': '002'},
+            update=True
         )
         self.assertIn('minorCivilDivisionCode', validator.errors)
 

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -1,5 +1,5 @@
 
-from unittest import TestCase
+from unittest import TestCase, skip
 
 from app import application
 from ..error_validator import ErrorValidator
@@ -1871,5 +1871,254 @@ class MapScaleTestCase(TestCase):
         self.assertIn('mapScale', validator.errors)
 
 
+class NationalWaterUseCodeTestCase(TestCase):
 
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('nationalWaterUseCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'nationalWaterUse': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('nationalWaterUseCode', validator.errors)
+
+    def test_valid_code_for_site_type(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'nationalWaterUseCode': 'DO'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'siteTypeCode': 'FA-CI'},
+            update=True
+        )
+        self.assertNotIn('nationalWaterUseCode', validator.errors)
+
+    def test_invalid_code_for_site_type(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'nationalWaterUseCode': 'DO'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'siteTypeCode': 'FA-FON'},
+            update=True
+        )
+        self.assertIn('nationalWaterUseCode', validator.errors)
+
+    # TODO: Add site type tests once fixed. Add tests for sites where nationalWaterUseCode must be null
+
+class PrimaryUseOfSiteTestCase(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('primaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('primaryUseOfSite', validator.errors)
+
+    def test_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('primaryUseOfSite', validator.errors)
+
+    def test_not_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('primaryUseOfSite', validator.errors)
+
+    def test_unique_primary_secondary_tertiary(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite' : 'C', 'tertiaryUseOfSiteCode': 'Z'},
+            update=True
+        )
+        self.assertNotIn('primaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'A', 'tertiaryUseOfSiteCode': 'Z'},
+            update=True
+        )
+        self.assertIn('primaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C', 'tertiaryUseOfSiteCode': 'A'},
+            update=True
+        )
+        self.assertIn('primaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C', 'tertiaryUseOfSiteCode': 'C'},
+            update=True
+        )
+        self.assertIn('primaryUseOfSite', validator.errors)
+
+    #TODO: Add site type tests. There are site types that must have primaryUseOfSite and site types that must not have a primaryUseOfSite
+
+
+class SecondaryUseOfSite(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('secondaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('secondaryUseOfSite', validator.errors)
+
+    def test_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            update=True
+        )
+        self.assertNotIn('secondaryUseOfSite', validator.errors)
+
+    def test_not_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            update=True
+        )
+        self.assertIn('secondaryUseOfSite', validator.errors)
+
+    def test_secondary_without_primary(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('secondaryUseOfSite', validator.errors)
+
+    #TODO: Add site type tests for sites that must have a secondaryUseOfSite
+
+
+class TertiaryUseOfSiteCode(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('tertiaryUseOfSiteCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('tertiaryUseOfSiteCode', validator.errors)
+
+    def test_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': 'Z'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A', 'secondaryUseOfSite': 'C'},
+            update=True
+        )
+        self.assertNotIn('tertiaryUseOfSiteCode', validator.errors)
+
+    def test_not_in_reference(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A', 'secondaryUseOfSite': 'C'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfSiteCode', validator.errors)
+
+    def test_tertiary_without_secondary(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfSiteCode', validator.errors)
+
+    #TODO: Add site type tests. Some site types must not have a tertiaryUseOfSiteCode
+
+
+class PrimaryUseOfWaterCodeTestCase(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('primaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('primaryUseOfWaterCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('primaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'AA'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('primaryUseOfWaterCode', validator.errors)
+
+    def test_valid_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('primaryUseOfWaterCode', validator.errors)
+
+    def test_invalid_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'G'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('primaryUseOfWaterCode', validator.errors)
+
+    def test_unique_primary_value(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'A'},
+            update=True
+        )
+        self.assertIn('primaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'B', 'tertiaryUseOfWaterCode': 'A'},
+            update=True
+        )
+        self.assertIn('primaryUseOfWaterCode', validator.errors)
 

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -2332,3 +2332,58 @@ class TopographicCodeTestCase(TestCase):
             update=True
         )
         self.assertIn('topographicCode', validator.errors)
+
+
+class InstrumentsCode(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('instrumentsCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': '   '},
+            {},
+            update=False
+        )
+        self.assertNotIn('instrumentsCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': 'YNYNYNYNYNYNYNYNYNYNYNYNYNYNYN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('instrumentsCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': 'YNYNYNYNYNYNYNYNYNYNYNYNYNYNYNY'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('instrumentsCode', validator.errors)
+
+    def test_invalid_characters(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': '  YYYYNNN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertNotIn('instrumentsCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': '  YYYXNNN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('instrumentsCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'instrumentsCode': '  YYY*NNN'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=True
+        )
+        self.assertIn('instrumentsCode', validator.errors)

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -1923,6 +1923,21 @@ class PrimaryUseOfSiteTestCase(TestCase):
         )
         self.assertNotIn('primaryUseOfSite', validator.errors)
 
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=False
+        )
+        self.assertNotIn('primaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'AA'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            update=False
+        )
+        self.assertIn('primaryUseOfSite', validator.errors)
+
     def test_in_reference(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
@@ -1988,6 +2003,21 @@ class SecondaryUseOfSite(TestCase):
         )
         self.assertNotIn('secondaryUseOfSite', validator.errors)
 
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            update=True
+        )
+        self.assertNotIn('secondaryUseOfSite', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'CC'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A'},
+            update=True
+        )
+        self.assertIn('secondaryUseOfSite', validator.errors)
+
     def test_in_reference(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfSite': 'C'},
@@ -2031,6 +2061,21 @@ class TertiaryUseOfSiteCode(TestCase):
             update=False
         )
         self.assertNotIn('tertiaryUseOfSiteCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': 'Z'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A', 'secondaryUseOfSite': 'C'},
+            update=True
+        )
+        self.assertNotIn('tertiaryUseOfSiteCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'tertiaryUseOfSiteCode': 'ZZ'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfSite': 'A', 'secondaryUseOfSite': 'C'},
+            update=True
+        )
+        self.assertIn('tertiaryUseOfSiteCode', validator.errors)
 
     def test_in_reference(self):
         validator.validate(
@@ -2107,7 +2152,7 @@ class PrimaryUseOfWaterCodeTestCase(TestCase):
         )
         self.assertIn('primaryUseOfWaterCode', validator.errors)
 
-    def test_unique_primary_value(self):
+    def test_unique_primary_secondary_tertiary_value(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'A'},
@@ -2122,3 +2167,62 @@ class PrimaryUseOfWaterCodeTestCase(TestCase):
         )
         self.assertIn('primaryUseOfWaterCode', validator.errors)
 
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'B',
+             'tertiaryUseOfWaterCode': 'B'},
+            update=True
+        )
+        self.assertIn('primaryUseOfWaterCode', validator.errors)
+
+
+class SecondaryUseOfWaterCodeTestCase(TestCase):
+
+    def test_optional(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'},
+            {},
+            update=False
+        )
+        self.assertNotIn('secondaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': ' '},
+            {},
+            update=False
+        )
+        self.assertNotIn('secondaryUseOfWaterCode', validator.errors)
+
+    def test_max_length(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'}
+        )
+        self.assertNotIn('secondaryUseOfWaterCode', validator.errors)
+
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'BB'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'}
+        )
+        self.assertIn('secondaryUseOfWaterCode', validator.errors)
+
+    def test_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'}
+        )
+        self.assertNotIn('secondaryUseOfWaterCode', validator.errors)
+
+    def test_not_in_ref_list(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'G'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'primaryUseOfWaterCode': 'A'}
+        )
+        self.assertIn('secondaryUseOfWaterCode', validator.errors)
+
+    def test_null_primary_with_secondary(self):
+        validator.validate(
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'secondaryUseOfWaterCode': 'B'},
+            {'agencyCode': 'USGS ', 'siteNumber': '12345678'}
+        )
+        self.assertIn('secondaryUseOfWaterCode', validator.errors)


### PR DESCRIPTION
Create validation test cases for nationalWaterUseCode, primarySiteUseCode, secondarySiteUseCode, tertiarySiteUseCode, primaryWaterUseCode, secondaryWaterUseCode, tertiaryWaterUseCode, topographicCode, instrumentsCode, dataTypesCode

Note that the site type tests will have to wait for MLR-233