### PR TITLE
Using an empty site type cross field json file temporarily to reduce …

### DIFF
--- a/mlrvalidator/references/temp_site_type_cross_field.json
+++ b/mlrvalidator/references/temp_site_type_cross_field.json
@@ -1,0 +1,3 @@
+{
+  "siteTypeCodes": []
+}

--- a/mlrvalidator/validators/cross_field_ref_error_validator.py
+++ b/mlrvalidator/validators/cross_field_ref_error_validator.py
@@ -21,7 +21,8 @@ class CrossFieldRefErrorValidator(BaseCrossFieldValidator):
         self.states_ref = States(os.path.join(reference_dir, 'state.json'))
         self.national_water_use_ref = NationalWaterUseCodes(os.path.join(reference_dir, 'national_water_use.json'))
         self.land_net_ref = LandNetCrossField(os.path.join(reference_dir, 'land_net.json'))
-        self.site_type_ref = SiteTypesCrossField(os.path.join(reference_dir, 'site_type_cross_field.json'))
+        # TODO: Replace with the regenerated site_type_cross_field.json file when available
+        self.site_type_ref = SiteTypesCrossField(os.path.join(reference_dir, 'temp_site_type_cross_field.json'))
 
     def _validate_counties(self):
         keys = ['countryCode', 'stateFipsCode', 'countyCode']
@@ -181,6 +182,7 @@ class CrossFieldRefErrorValidator(BaseCrossFieldValidator):
         self._validate_mcd()
         self._validate_states()
         self._validate_national_water_use_code()
+
         self._validate_site_type()
         self._validate_land_net()
         self._validate_state_latitude_range()

--- a/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
+++ b/mlrvalidator/validators/tests/test_end_to_end_error_validator.py
@@ -1118,6 +1118,8 @@ class NationalAquiferCodeTestCase(TestCase):
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'RM', 'stateFipsCode': '02'}, update=True)
         self.assertIn('nationalAquiferCode', validator.errors)
 
+    #TODO: Put back in when site type cross field json has been regenerated
+    '''
     def test_invalid_non_null_code_site_type(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'nationalAquiferCode': 'N100AKUNCD'},
@@ -1128,7 +1130,7 @@ class NationalAquiferCodeTestCase(TestCase):
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'nationalAquiferCode': 'N100AKUNCD'},
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'siteTypeCode': 'FA-CI'}, update=True)
         self.assertIn('siteTypeCode', validator.errors)
-
+    '''
 
 class AquiferCodeTestCase(TestCase):
 
@@ -1169,6 +1171,8 @@ class AquiferCodeTestCase(TestCase):
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'countryCode': 'US', 'stateFipsCode': '80'}, update=True)
         self.assertIn('aquiferCode', validator.errors)
 
+    #TODO: Put back in when site type cross field json is regenerate
+    '''
     def test_invalid_non_null_code_for_site_type(self):
         validator.validate(
             {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'aquiferCode': '400PCMB'},
@@ -1184,7 +1188,7 @@ class AquiferCodeTestCase(TestCase):
             update=True
         )
         self.assertIn('siteTypeCode', validator.errors)
-
+    '''
 
 class AquiferTypeCodeTestCase(TestCase):
 
@@ -1215,6 +1219,8 @@ class AquiferTypeCodeTestCase(TestCase):
                            {'agencyCode': 'USGS ', 'siteNumber': '12345678'}, update=True)
         self.assertIn('aquiferTypeCode', validator.errors)
 
+    #TODO: Put back in when site type cross field json has been regenerated
+    '''
     def test_invalid_non_null_code_for_site_type(self):
         validator.validate({'agencyCode': 'USGS ', 'siteNumber': '12345678', 'aquiferTypeCode': 'U'},
                            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'siteTypeCode': 'ST-CA'}, update=True)
@@ -1223,7 +1229,7 @@ class AquiferTypeCodeTestCase(TestCase):
         validator.validate({'agencyCode': 'USGS ', 'siteNumber': '12345678', 'aquiferTypeCode': 'U'},
                            {'agencyCode': 'USGS ', 'siteNumber': '12345678', 'siteTypeCode': 'FA-CI'}, update=True)
         self.assertIn('siteTypeCode', validator.errors)
-
+    '''
 
 class AgencyUseCodeTestCase(TestCase):
 


### PR DESCRIPTION
…the number of false negatives that the validator generates with the current site_type_cross_field.json.