### PR TITLE
add more context to longitude validation error messages, including va…

### DIFF
--- a/mlrvalidator/validators/single_field_validator.py
+++ b/mlrvalidator/validators/single_field_validator.py
@@ -195,9 +195,9 @@ class SingleFieldValidator(Validator):
                 if not ((first_val in "- ") and (0 <= int(check_degrees) <= 180) and (
                         0 <= int(check_minutes) < 60) and (0 <= int(check_seconds) < 60)
                         and check_100th_seconds(rstripped_value)):
-                    self._error(field, error_message + "; Validation error: " + rstripped_value)
+                    self._error(field, error_message + "; Validation error: " + "*" + rstripped_value + "*")
             except ValueError:
-                self._error(field, error_message + "; ValueError: " + rstripped_value)
+                self._error(field, error_message + "; ValueError: " + "*" + rstripped_value + "*")
 
     def _validate_valid_date(self, valid_date, field, value):
         # Check that field is a formatted date of YYYY, YYYYMM or YYYYMMDD


### PR DESCRIPTION
…lue that was attempted to be validated surrounded by a character to show whitespace.