### PR TITLE
MLR-390: remove duplicate site check

### DIFF
--- a/mlrvalidator/validators/error_validator.py
+++ b/mlrvalidator/validators/error_validator.py
@@ -36,22 +36,14 @@ class ErrorValidator:
         self.cross_field_validator.validate(ddot_location, existing_location)
         self.cross_field_ref_validator.validate(ddot_location, existing_location)
 
-        duplicate_error = {}
         if update:
             self.transition_validator.validate(ddot_location, existing_location)
             transition_errors = self.transition_validator.errors
         else:
             transition_errors = {}
-            if existing_location != {}:
-                duplicate_error = {
-                    'duplicate_site': [
-                        'Site with agencyCode {0} and siteNumber {1} already exists'.format(existing_location.get('agencyCode'),
-                                                                                             existing_location.get('siteNumber'))]
-                }
 
         self._errors = defaultdict(list)
         all_errors = chain(
-            duplicate_error.items(),
             self.single_field_validator.errors.items(),
             self.cross_field_validator.errors.items(),
             self.cross_field_ref_validator.errors.items(),

--- a/mlrvalidator/validators/tests/test_error_validator.py
+++ b/mlrvalidator/validators/tests/test_error_validator.py
@@ -137,14 +137,6 @@ class ErrorValidatorErrorsTestCase(TestCase):
         self.assertEqual(len(validator.errors.get('A')), 1)
         self.assertEqual(len(validator.errors.get('B')), 3)
 
-    def test_duplicate_site_error(self, mtran_class, mref_class, mcross_class, msingle_field_class):
-        self.setUpPassingValidators(mtran_class, mref_class, mcross_class, msingle_field_class)
-
-        validator = ErrorValidator('schema_dir', 'ref_dir')
-        self.assertFalse(validator.validate({'agencyCode': 'USGS', 'siteNumber': '12345678'}, {'agencyCode': 'USGS', 'siteNumber': '12345678'}))
-        self.assertEqual(len(validator.errors), 1)
-        self.assertTrue('duplicate_site' in validator.errors)
-
 
 
 


### PR DESCRIPTION
The CRU also does this and it leads to twice the output, we decided to remove it from the validator and let the CRU handle it.