### PR TITLE
Move error var inside validate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,23 @@ your local .env file. See http://flask-jwt-simple.readthedocs.io/en/latest/optio
 you can use.
 
 ## Connecting with mlr-local-dev
-You can run the MLR-Validator locally alongside the [mlr-local-dev](https://github.com/USGS-CIDA/mlr-local-dev) project which runs the other MLR application services. This gives you the option of debugging the Validator through the MLR UI rather than through Swagger. Use the instructions on mlr-local-dev to set that up. Then in the `.env` file you created, add
+You can run the MLR-Validator locally alongside the [mlr-local-dev](https://github.com/USGS-CIDA/mlr-local-dev) project which runs the other MLR application services in Docker. This gives you the option of debugging the Validator through the MLR UI rather than through Swagger. There are small config changes as well as needing to run the Validator with https.
+
+Use the instructions on mlr-local-dev to get it running with two differences: 
+
+Modify the path to the Validator that the [mlr-gateway](https://github.com/USGS-CIDA/mlr-local-dev/blob/master/docker-reference/configuration/mlr-gateway/config.env#L10) configuration has, to point at the non-Docker Validator service instead.
+```yaml
+mlrgateway_legacyValidatorServers=https://localhost:5000
+```
+When starting the services in Terminal 3, remove the `mlr-validator` from the `docker-compose up` command suggested in the [Running](https://github.com/USGS-CIDA/mlr-local-dev#running) section
+
+Then in the `.env` file you created, add:
 ```python
 SERVICE_CERT_PATH="/home/user/mlr/mlr-local-dev/ssl/wildcard.crt"
 SERVICE_CERT_KEY="/home/user/mlr/mlr-local-dev/ssl/wildcard.key"
 ```
+
+To run the Validator with the cert and public key from mlr-local-dev:
 
 Then in the `app.py` file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
 ```python
@@ -63,3 +75,7 @@ if __name__ == '__main__':
     key = application.config['SERVICE_CERT_KEY']
     application.run(ssl_context=(cert, key))
 ```
+
+When you start debugging, it should now run securely at https://127.0.0.1:5000/api and debugging through the MLR UI is now possible.
+
+

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SERVICE_CERT_PATH="/home/user/mlr/mlr-local-dev/ssl/wildcard.crt"
 SERVICE_CERT_KEY="/home/user/mlr/mlr-local-dev/ssl/wildcard.key"
 ```
 
-Then in the app.py file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
+Then in the `app.py` file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
 ```python
 if __name__ == '__main__':
     cert = application.config['SERVICE_CERT_PATH']

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ SERVICE_CERT_KEY="/home/user/mlr/mlr-local-dev/ssl/wildcard.key"
 
 To run the Validator with the cert and public key from mlr-local-dev:
 
-Then in the `app.py` file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
+In the Validator's `app.py` file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
 ```python
 if __name__ == '__main__':
     cert = application.config['SERVICE_CERT_PATH']

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ jwt.encode({'authorities': ['one_role', 'two_role']}, 'secret', algorithm='HS256
 The output of this command will be the token that you can use. You will need to set JWT_SECRET_KEY to 'secret' in 
 your local .env file. See http://flask-jwt-simple.readthedocs.io/en/latest/options.html for the other options that 
 you can use.
+
+## Connecting with mlr-local-dev
+You can run the MLR-Validator locally alongside the [mlr-local-dev](https://github.com/USGS-CIDA/mlr-local-dev) project which runs the other MLR application services. This gives you the option of debugging the Validator through the MLR UI rather than through Swagger. Use the instructions on mlr-local-dev to set that up. Then in the `.env` file you created, add
+```python
+SERVICE_CERT_PATH="/home/user/mlr/mlr-local-dev/ssl/wildcard.crt"
+SERVICE_CERT_KEY="/home/user/mlr/mlr-local-dev/ssl/wildcard.key"
+```
+
+Then in the app.py file, modify the last few lines to include pulling the cert path and cert key from mlr-local-dev into new strings we'll use to run the Flask app securely:
+```python
+if __name__ == '__main__':
+    cert = application.config['SERVICE_CERT_PATH']
+    key = application.config['SERVICE_CERT_KEY']
+    application.run(ssl_context=(cert, key))
+```

--- a/mlrvalidator/validators/tests/test_transition_validator.py
+++ b/mlrvalidator/validators/tests/test_transition_validator.py
@@ -62,3 +62,18 @@ class TransitionValidatorSiteTypeTestCase2(TestCase):
 
     def test_valid_transition(self):
         self.assertFalse(self.validator.validate({'siteTypeCode': 'FA-DV'}, {'siteTypeCode': 'AG'}))
+
+class TransitionValidatorErrorsClearAfterEachUse(TestCase):
+
+    @mock.patch('mlrvalidator.validators.transition_validator.SiteTypeInvalidCodes')
+    @mock.patch('mlrvalidator.validators.transition_validator.FieldTransitions')
+    def setUp(self, mfield_transitions, msite_type_invalid_codes):
+    
+        msite_type_invalid_codes.return_value.get_site_type_invalid_codes.return_value = ['FA', 'SS']
+        mfield_transitions.return_value.get_allowed_transitions.return_value = ['FA-SPS','FA-WIW','GW', 'FA-DV']
+        self.validator = TransitionValidator('ref_dir')
+
+    def test_invalid_transition_errors_response_population(self):
+        self.assertFalse(self.validator.validate({}, {'siteTypeCode': 'SS'}))
+        self.assertTrue(self.validator.validate({'siteTypeCode': 'FA-DV'}, {'siteTypeCode': 'AS'}))
+

--- a/mlrvalidator/validators/transition_validator.py
+++ b/mlrvalidator/validators/transition_validator.py
@@ -6,12 +6,13 @@ from .reference import SiteTypeInvalidCodes, FieldTransitions
 class TransitionValidator:
 
     def __init__(self, reference_dir):
-        self._errors = {}
         self.site_type_invalid_code_list = []
         self.site_type_transition_ref = FieldTransitions(os.path.join(reference_dir, 'site_type_transition.json'))
         self.site_type_invalid_code_list = SiteTypeInvalidCodes(os.path.join(reference_dir, 'site_type_invalid.json'))
 
     def validate(self, document, existing_document):
+        self._errors = {}
+
         existing_value = existing_document.get('siteTypeCode', '').strip()
         new_value = document.get('siteTypeCode', '').strip()
 

--- a/mlrvalidator/validators/transition_validator.py
+++ b/mlrvalidator/validators/transition_validator.py
@@ -6,6 +6,7 @@ from .reference import SiteTypeInvalidCodes, FieldTransitions
 class TransitionValidator:
 
     def __init__(self, reference_dir):
+        self._errors = {}
         self.site_type_invalid_code_list = []
         self.site_type_transition_ref = FieldTransitions(os.path.join(reference_dir, 'site_type_transition.json'))
         self.site_type_invalid_code_list = SiteTypeInvalidCodes(os.path.join(reference_dir, 'site_type_invalid.json'))


### PR DESCRIPTION
otherwise, previous errors thrown were sticking around for other unrelated transactions.

update readme to include information on running the validator alongside mlr-local-dev as well as configuration changes needed to support that.